### PR TITLE
LockSettingFragment 뒤로가기 에러 수정

### DIFF
--- a/app/src/main/java/com/nbcam_final_account_book/persentation/lock/LockActivity.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/lock/LockActivity.kt
@@ -22,6 +22,10 @@ class LockActivity : AppCompatActivity() {
         initView()
     }
 
+    override fun onBackPressed() {
+        finish()
+    }
+
     fun initView() = with(binding) {
         lockRadioGroup.setOnCheckedChangeListener { _, checkedId ->
             when (checkedId) {

--- a/app/src/main/res/layout/lock_activity.xml
+++ b/app/src/main/res/layout/lock_activity.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/lock_fragment_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="10dp"
@@ -84,7 +85,7 @@
             android:src="@drawable/ic_warning"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            tools:ignore="contentDescription"/>
+            tools:ignore="contentDescription" />
 
         <TextView
             android:layout_width="0dp"
@@ -96,13 +97,4 @@
             app:layout_constraintStart_toEndOf="@+id/lock_warning"
             app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <FrameLayout
-        android:id="@+id/lock_fragment_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
1. 뒤로가기를 하면 보이는 백스택을 강제적으로 finish해서 안보이게 함
   - LockActivity에 있는 내용을 따로 Fragment로 만들어서 LockSettingFragment와 Navigation으로 왔다갔다 하는걸로 고쳐야 함!(ㅠㅠㅜㅠ대공사...)
2. lock_fragment_container를 FrameLayout에 따로 지정하지 않고 lock_activity.xml의 ConstraintLayout 자체에 설정함
close #30 