### PR TITLE
툴바 가계부 이름 표시 및 템플릿 다이얼로그

### DIFF
--- a/app/src/main/java/com/nbcam_final_account_book/persentation/dialog/template/TemplateDialogAdapter.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/dialog/template/TemplateDialogAdapter.kt
@@ -5,13 +5,12 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.nbcam_final_account_book.data.model.local.EntryEntity
 import com.nbcam_final_account_book.data.model.local.TemplateEntity
 import com.nbcam_final_account_book.databinding.TemplateSelectItemBinding
 
 class TemplateDialogAdapter(
     private val onItemClick: (TemplateEntity) -> Unit,
-    private val onItemLongClick: (TemplateEntity) -> Unit,
+    private val onItemDeleteClick: (TemplateEntity) -> Unit,
 
     ) : ListAdapter<TemplateEntity, TemplateDialogAdapter.ViewHolder>(
     object : DiffUtil.ItemCallback<TemplateEntity>() {
@@ -32,7 +31,7 @@ class TemplateDialogAdapter(
             TemplateSelectItemBinding.inflate(
                 LayoutInflater.from(parent.context), parent, false
             ), onItemClick
-            , onItemLongClick
+            , onItemDeleteClick
 
         )
     }
@@ -46,7 +45,7 @@ class TemplateDialogAdapter(
     class ViewHolder(
         private val binding: TemplateSelectItemBinding,
         private val onItemClick: (TemplateEntity) -> Unit,
-        private val onItemLongClick: (TemplateEntity) -> Unit,
+        private val onItemDeleteClick: (TemplateEntity) -> Unit,
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(item: TemplateEntity) = with(binding) {
 
@@ -57,7 +56,7 @@ class TemplateDialogAdapter(
             }
 
             itemView.setOnLongClickListener{
-                onItemLongClick(item)
+                onItemDeleteClick(item)
 
                 true
             }

--- a/app/src/main/java/com/nbcam_final_account_book/persentation/dialog/template/TemplateDialogFragment.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/dialog/template/TemplateDialogFragment.kt
@@ -15,6 +15,10 @@ import com.nbcam_final_account_book.data.model.local.TemplateEntity
 import com.nbcam_final_account_book.databinding.TemplateSelectDialogBinding
 import com.nbcam_final_account_book.persentation.main.MainViewModel
 import com.nbcam_final_account_book.persentation.template.TemplateActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class TemplateDialogFragment() : DialogFragment() {
 
@@ -38,8 +42,10 @@ class TemplateDialogFragment() : DialogFragment() {
             onItemClick = { item ->
                 replaceAlterDialog(item)
             },
-            onItemLongClick = {item->
-                viewModel.removeTemplate(item)
+
+            onItemDeleteClick = { item ->
+                deleteTemplate(item)
+
             }
         )
     }
@@ -79,13 +85,27 @@ class TemplateDialogFragment() : DialogFragment() {
 
                     adapter.submitList(it)
                     btnVisibility(it)
-                    Log.d("다이얼로그사이즈", it.size.toString())
+                    Log.d("템플릿사이즈", it.size.toString())
 
                 } // if
             } // observe
 
 
         }
+    }
+
+    private fun deleteTemplate(item: TemplateEntity) {
+        CoroutineScope(Dispatchers.IO).launch {
+
+            if (!viewModel.cantDelete()) {
+
+                viewModel.removeTemplate(item)
+                val default = viewModel.getDefaultTemplate()
+
+                sharedViewModel.updateCurrentTemplateInCo(default)
+
+            }//canDelete
+        }//CoroutineScope
     }
 
 
@@ -97,6 +117,12 @@ class TemplateDialogFragment() : DialogFragment() {
     private fun btnVisibility(list: List<TemplateEntity>) {
         binding.templateBtnAdd.visibility =
             if (viewModel.getTemplateSizeInTemplateDialog(list)) View.VISIBLE else View.INVISIBLE
+    }
+
+    private fun canDelete(list: List<TemplateEntity>): Boolean {
+        Log.d("삭제", list.size.toString())
+        return viewModel.cantDelete(list)
+
     }
 
     private fun replaceAlterDialog(item: TemplateEntity) {

--- a/app/src/main/java/com/nbcam_final_account_book/persentation/dialog/template/TemplateDialogViewModel.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/dialog/template/TemplateDialogViewModel.kt
@@ -4,14 +4,13 @@ import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
 import com.nbcam_final_account_book.data.model.local.DeleteEntity
 import com.nbcam_final_account_book.data.model.local.TemplateEntity
 import com.nbcam_final_account_book.data.repository.room.RoomRepository
 import com.nbcam_final_account_book.data.repository.room.RoomRepositoryImpl
 import com.nbcam_final_account_book.data.room.AndroidRoomDataBase
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class TemplateDialogViewModel(
     private val roomRepo: RoomRepository
@@ -19,28 +18,41 @@ class TemplateDialogViewModel(
 
     val dialogLiveTemplateList: LiveData<List<TemplateEntity>> get() = roomRepo.getAllLiveTemplate()
 
+
     fun getTemplateSizeInTemplateDialog(list: List<TemplateEntity>): Boolean {
         return list.size < 3
     }
 
-    fun removeTemplate(item: TemplateEntity) {
+    fun cantDelete(list: List<TemplateEntity>): Boolean {
+        return list.isNotEmpty()
+    }
 
-        viewModelScope.launch(Dispatchers.IO) {
-            val key = item.id
-            val deleteEntity = DeleteEntity(key = key)
-            with(roomRepo) {
-                insertDelete(deleteEntity)
-                deleteTemplate(item)
-                deleteDataByKey(key)
-                deleteBudgetByKey(key)
-                deleteEntryByKey(key)
-                deleteTagByKey(key)
-            }
-
-
+    suspend fun removeTemplate(item: TemplateEntity) {
+        val key = item.id
+        val deleteEntity = DeleteEntity(key = key)
+        with(roomRepo) {
+            insertDelete(deleteEntity)
+            deleteTemplate(item)
+            deleteDataByKey(key)
+            deleteBudgetByKey(key)
+            deleteEntryByKey(key)
+            deleteTagByKey(key)
         }
 
     }
+
+    suspend fun getDefaultTemplate(): TemplateEntity? = withContext(Dispatchers.IO) {
+        val list = roomRepo.getAllListTemplate()
+
+        if (list.isNotEmpty()) list[0] else null
+    }
+
+    suspend fun cantDelete(): Boolean = withContext(Dispatchers.IO) {
+        val list = roomRepo.getAllListTemplate()
+
+        list.size == 1
+    }
+
 
 }
 

--- a/app/src/main/java/com/nbcam_final_account_book/persentation/main/MainActivity.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/main/MainActivity.kt
@@ -128,6 +128,7 @@ class MainActivity : AppCompatActivity() {
                     saveSharedPrefCurrentUser(it)
                     Log.d("키값.현재", it.toString())
                     setKey()
+                    setTitle(it)
                 }
                 Log.d("옵저빙.템플릿", it.toString())
             })
@@ -159,6 +160,11 @@ class MainActivity : AppCompatActivity() {
 
         }
 
+    }
+
+    private fun setTitle(item: TemplateEntity?) {
+        if (item == null) return
+        binding.toolbarTitle.text = item.templateTitle
     }
 
     private fun hideActionBar() {

--- a/app/src/main/java/com/nbcam_final_account_book/persentation/main/MainViewModel.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/main/MainViewModel.kt
@@ -90,6 +90,13 @@ class MainViewModel(
         _mainLiveCurrentTemplate.value = item
     }
 
+    suspend fun updateCurrentTemplateInCo(item: TemplateEntity?) {
+        if (item == null) return
+        _mainLiveCurrentTemplate.postValue(item)
+        //postValue의 단점 : 쓰레드에 직접적으로 관련하지 않기 때문에 여러 데이터가 변경되지 않는 상황에서는 명확한 값이 지정될 수 없음
+        //ex) 주식 차트 혹은 코인 차트같이 움직이는 라이브 데이터 같은 상황에서는 사용하지 않는게 좋음
+    }
+
     //템플릿 룸으로 백업 데이터를 저장 혹은 업데이트 해주는 로직
     //템플릿이 전환되는 순간에 호출되어야 함.
     fun updataBackupData() = with(roomRepo) {
@@ -128,14 +135,14 @@ class MainViewModel(
 
             }
 
-            if (deleteKey.isNotEmpty()){
-                for (key in deleteKey){
-                    fireRepo.deleteData(user,key.key)
-                    fireRepo.deleteTemplate(user,key.key)
+            if (deleteKey.isNotEmpty()) {
+                for (key in deleteKey) {
+                    fireRepo.deleteData(user, key.key)
+                    fireRepo.deleteTemplate(user, key.key)
                 }
             }
             roomRepo.deleteAllDeleteEntity()
-            Log.d("딜리트",deleteKey.size.toString())
+            Log.d("딜리트", deleteKey.size.toString())
             saveSharedPrefIsLogin(false)
             roomRepo.deleteAllData()
         }
@@ -154,15 +161,15 @@ class MainViewModel(
                 fireRepo.updateData(user, dataEntity)
             }
 
-            if (deleteKey.isNotEmpty()){
-                for (key in deleteKey){
-                    fireRepo.deleteData(user,key.key)
-                    fireRepo.deleteTemplate(user,key.key)
+            if (deleteKey.isNotEmpty()) {
+                for (key in deleteKey) {
+                    fireRepo.deleteData(user, key.key)
+                    fireRepo.deleteTemplate(user, key.key)
                 }
             }
 
             roomRepo.deleteAllDeleteEntity()
-            Log.d("딜리트",deleteKey.size.toString())
+            Log.d("딜리트", deleteKey.size.toString())
         }
     }
 

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -14,7 +14,16 @@
         android:elevation="3dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/toolbar_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:textSize="20sp"
+            android:textStyle="bold" />
+    </androidx.appcompat.widget.Toolbar>
 
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/main_bottom_navi"


### PR DESCRIPTION
1. 툴바 가계부 이름 표시
  - 메인 툴바에 타이틀을 담당하는 textview를 삽입한 뒤 중앙정렬하여 해당 부분에 현재 템플릿의 이름을 삽입하였습니다.

2.  템플릿 삭제 로직 싱크 맞춤
  - 코루틴 스코프가 맞지 않아 각자 타이밍이 맞지 않은 함수들의 코루틴 스코프를 맞췄습니다.
  - CoroutineScope(Dispatchers.IO)에서 모두 작동할 수 있도록 livedata data를 postvalue로 설정해주었습니다.

#61 
