### PR TITLE
비밀번호 변경 다이얼로그 수정

### DIFF
--- a/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/MyPageFragment.kt
@@ -451,7 +451,8 @@ class MyPageFragment : Fragment() {
 
     // Change the password
     private fun showChangePasswordDialog() {
-        MyPageChangePasswordDialog(requireContext())
+        val dialog = MyPageChangePasswordDialog()
+        dialog.show(parentFragmentManager, "MyPageChangePasswordDialog")
     }
 
     // Logout

--- a/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/mypagedialog/MyPageChangePasswordDialog.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/mypagedialog/MyPageChangePasswordDialog.kt
@@ -1,65 +1,112 @@
 package com.nbcam_final_account_book.persentation.mypage.mypagedialog
 
+import android.app.AlertDialog
+import android.app.Dialog
 import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
+import android.view.Window
 import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
 import com.nbcam_final_account_book.R
+import com.nbcam_final_account_book.databinding.MyPageChangePasswordDialogBinding
 
-class MyPageChangePasswordDialog(context: Context) {
+class MyPageChangePasswordDialog : DialogFragment() {
 
-    private val alertDialog: AlertDialog
-    private val mContext: Context
-    private val currentPasswordInputLayout: TextInputLayout
-    private val currentPasswordEditText: TextInputEditText
-    private val newPasswordInputLayout: TextInputLayout
-    private val newPasswordEditText: TextInputEditText
-    private val confirmPasswordInputLayout: TextInputLayout
-    private val confirmPasswordEditText: TextInputEditText
+    private var _binding: MyPageChangePasswordDialogBinding? = null
+    private val binding get() = _binding!!
+    private lateinit var mContext: Context
+    private lateinit var alertDialog: AlertDialog
 
-    init {
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
         mContext = context
-
-        val dialogView = View.inflate(context, R.layout.my_page_change_password_dialog, null)
-        currentPasswordInputLayout = dialogView.findViewById(R.id.current_password_input_layout)
-        currentPasswordEditText = currentPasswordInputLayout.findViewById(R.id.current_password_ev)
-        newPasswordInputLayout = dialogView.findViewById(R.id.new_password_input_layout1)
-        newPasswordEditText = newPasswordInputLayout.findViewById(R.id.new_password_ev1)
-        confirmPasswordInputLayout = dialogView.findViewById(R.id.confirm_password_input_layout)
-        confirmPasswordEditText = confirmPasswordInputLayout.findViewById(R.id.confirm_password_ev)
-
-        val newTextWatcher = createTextWatcher(newPasswordEditText, newPasswordInputLayout)
-        val confirmTextWatcher = createTextWatcher(confirmPasswordEditText, confirmPasswordInputLayout)
-
-        alertDialog = AlertDialog.Builder(context, R.style.EditNameAlertDialogStyle)
-            .setTitle("비밀번호 변경")
-            .setView(dialogView)
-            .setPositiveButton("저장") { _, _ ->
-                val currentPassword = currentPasswordEditText.text.toString()
-                val newPassword = confirmPasswordEditText.text.toString()
-                val confirmPassword = confirmPasswordEditText.text.toString()
-                reauthenticateAndChangePassword(currentPassword, newPassword, confirmPassword)
-            }
-            .setNegativeButton("취소") { dialog, _ ->
-                dialog.dismiss()
-            }
-            .create()
-
-        newPasswordEditText.addTextChangedListener(newTextWatcher)
-        confirmPasswordEditText.addTextChangedListener(confirmTextWatcher)
-        alertDialog.show()
-        alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = false
     }
 
-    private fun reauthenticateAndChangePassword(currentPassword: String, newPassword: String, confirmPassword: String) {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = MyPageChangePasswordDialogBinding.inflate(inflater, container, false)
+
+        return binding.root
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        _binding = MyPageChangePasswordDialogBinding.inflate(layoutInflater, null, false)
+        val dialog = Dialog(requireContext())
+        dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+        dialog.setContentView(binding.root)
+        return dialog
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        val width = (resources.displayMetrics.widthPixels * 0.85).toInt()
+        val height = ViewGroup.LayoutParams.WRAP_CONTENT
+        dialog?.window?.setLayout(width, height)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initView()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun initView() = with(binding) {
+        val newTextWatcher = createTextWatcher(newPasswordEv, newPasswordInputLayout)
+        val confirmTextWatcher = createTextWatcher(confirmPasswordEv, confirmPasswordInputLayout)
+
+        alertDialog = AlertDialog.Builder(mContext, R.style.EditNameAlertDialogStyle)
+            .setTitle("비밀번호 변경")
+            .setView(root)
+            .setNegativeButton("취소", null)
+            .setPositiveButton("저장", null)
+            .create().apply {
+                setCancelable(false)
+            }
+
+        tvDialogCancel.setOnClickListener {
+            dismiss()
+        }
+
+        tvDialogSave.isEnabled = false
+        tvDialogSave.setOnClickListener {
+            // 저장 버튼 클릭 시 수행할 작업을 여기에 추가
+            val currentPassword = currentPasswordEv.text.toString()
+            val newPassword = newPasswordEv.text.toString()
+            val confirmPassword = confirmPasswordEv.text.toString()
+            reauthenticateAndChangePassword(currentPassword, newPassword, confirmPassword)
+        }
+
+        newPasswordEv.addTextChangedListener(newTextWatcher)
+        confirmPasswordEv.addTextChangedListener(confirmTextWatcher)
+    }
+
+    private fun reauthenticateAndChangePassword(
+        currentPassword: String,
+        newPassword: String,
+        confirmPassword: String
+    ) {
         val currentUser = FirebaseAuth.getInstance().currentUser
-        val credential = EmailAuthProvider.getCredential(currentUser!!.email!!, currentPassword)
+        val credential = EmailAuthProvider.getCredential(currentUser?.email!!, currentPassword)
 
         currentUser.reauthenticate(credential)
             .addOnCompleteListener { reauthTask ->
@@ -68,17 +115,17 @@ class MyPageChangePasswordDialog(context: Context) {
                         currentUser.updatePassword(newPassword)
                             .addOnCompleteListener { passwordUpdateTask ->
                                 if (passwordUpdateTask.isSuccessful) {
-                                    Toast.makeText(mContext, "비밀번호가 변경되었습니다.", Toast.LENGTH_LONG).show()
-                                    alertDialog.dismiss()
+                                    mContext.showToast("비밀번호가 변경되었습니다.")
+                                    dismiss()
                                 } else {
-                                    Toast.makeText(mContext, "비밀번호 변경에 실패했습니다.", Toast.LENGTH_LONG).show()
+                                    mContext.showToast("비밀번호 변경에 실패했습니다.")
                                 }
                             }
                     } else {
-                        Toast.makeText(mContext, "새로운 비밀번호와 확인 비밀번호가 일치하지 않습니다.", Toast.LENGTH_LONG).show()
+                        mContext.showToast("새로운 비밀번호와 확인 비밀번호가 일치하지 않습니다.")
                     }
                 } else {
-                    Toast.makeText(mContext, "현재 비밀번호가 올바르지 않습니다.", Toast.LENGTH_LONG).show()
+                    mContext.showToast("현재 비밀번호가 올바르지 않습니다.")
                 }
             }
     }
@@ -86,26 +133,26 @@ class MyPageChangePasswordDialog(context: Context) {
     private fun createTextWatcher(
         editText: TextInputEditText,
         inputLayout: TextInputLayout
-    ): TextWatcher {
+    ): TextWatcher = with(binding) {
         return object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
 
             override fun afterTextChanged(s: Editable?) {
-                val newPassword = newPasswordEditText.text.toString()
-                val confirmPassword = confirmPasswordEditText.text.toString()
+                val newPassword = newPasswordEv.text.toString()
+                val confirmPassword = confirmPasswordEv.text.toString()
 
                 val isNewPasswordValid = isPasswordValid(newPassword)
                 val isNewPasswordConfirmed = newPassword == confirmPassword
 
                 inputLayout.error = when (editText) {
-                    newPasswordEditText -> if (isNewPasswordValid || newPassword.isEmpty()) "" else "비밀번호는 알파벳, 숫자, 특수문자를 혼합하여 8~20자로 입력해주세요."
-                    confirmPasswordEditText -> if (isNewPasswordConfirmed || confirmPassword.isEmpty()) "" else "비밀번호가 일치하지 않습니다."
+                    newPasswordEv -> if (isNewPasswordValid || newPassword.isEmpty()) "" else "비밀번호는 알파벳, 숫자, 특수문자를 혼합하여 8~20자로 입력해주세요."
+                    confirmPasswordEv -> if (isNewPasswordConfirmed || confirmPassword.isEmpty()) "" else "비밀번호가 일치하지 않습니다."
                     else -> ""
                 }
 
                 val isFormValid = isNewPasswordValid && isNewPasswordConfirmed
-                alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).isEnabled = isFormValid
+                tvDialogSave.isEnabled = isFormValid
             }
         }
     }
@@ -113,5 +160,9 @@ class MyPageChangePasswordDialog(context: Context) {
     private fun isPasswordValid(password: String): Boolean {
         val passwordRegex = Regex("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#\$%^&*]).{8,20}\$")
         return passwordRegex.matches(password)
+    }
+
+    private fun Context.showToast(msg: String) {
+        Toast.makeText(this, msg, Toast.LENGTH_LONG).show()
     }
 }

--- a/app/src/main/res/color/btn_text_color.xml
+++ b/app/src/main/res/color/btn_text_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/text_highlight" android:state_enabled="true"/>
+    <item android:color="@color/text_primary" />
+</selector>

--- a/app/src/main/res/layout/my_page_change_password_dialog.xml
+++ b/app/src/main/res/layout/my_page_change_password_dialog.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/padding">
+    android:background="@drawable/shape_round"
+    android:padding="@dimen/padding"
+    tools:context=".persentation.mypage.mypagedialog.MyPageChangePasswordDialog">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/current_password_input_layout"
@@ -27,21 +30,23 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/new_password_input_layout1"
+        android:id="@+id/new_password_input_layout"
         style="@style/TextInputLayoutStyle"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/field_margin_vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/current_password_input_layout">
+        app:layout_constraintTop_toBottomOf="@+id/current_password_input_layout"
+        app:passwordToggleEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/new_password_ev1"
+            android:id="@+id/new_password_ev"
             style="@style/TextInputEditTextStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="새로운 비밀번호"
+            android:inputType="textPassword"
             android:padding="@dimen/edit_text_padding" />
     </com.google.android.material.textfield.TextInputLayout>
 
@@ -53,7 +58,8 @@
         android:layout_marginTop="@dimen/field_margin_vertical"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/new_password_input_layout1">
+        app:layout_constraintTop_toBottomOf="@+id/new_password_input_layout"
+        app:passwordToggleEnabled="true">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/confirm_password_ev"
@@ -61,6 +67,44 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="새로운 비밀번호 확인"
+            android:inputType="textPassword"
             android:padding="@dimen/edit_text_padding" />
     </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:id="@+id/tv_dialog_cancel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="10dp"
+        android:text="취소"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/divider"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/confirm_password_input_layout" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="1dp"
+        android:layout_height="0dp"
+        android:background="@color/text_primary"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="@+id/tv_dialog_cancel"
+        app:layout_constraintEnd_toStartOf="@+id/tv_dialog_save"
+        app:layout_constraintStart_toEndOf="@+id/tv_dialog_cancel"
+        app:layout_constraintTop_toTopOf="@+id/tv_dialog_cancel" />
+
+    <TextView
+        android:id="@+id/tv_dialog_save"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="저장"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+        android:textColor="@color/btn_text_color"
+        app:layout_constraintBottom_toBottomOf="@+id/divider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/divider"
+        app:layout_constraintTop_toTopOf="@+id/divider" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 구현 사항
1. 비밀번호 다이얼로그 레이아웃 수정
   - 취소/저장 버튼 xml에 직접 작성
   - 비밀번호 toggle 설정
3. MyPageFragment에서 다이얼로그 표시 방식 수정
    - MyPageChangePasswordDialog를 직접 생성하지 않고 다이얼로그의 인스턴스를 생성하도록 변경
    - parentFragmentManager 사용
4. MyPageChangePasswordDialog 코드 리팩토링
    - DialogFragment 상속
    - ViewBinding 사용
    - Toast 확장함수 생성
## 주요 변동 파일
- MyPageFragment.kt
- MyPageChangePasswordDialog.kt
- my_page_change_password_dialog.xml
---
close #251 