### PR TITLE
사용자 이름 수정 관련 코드 수정

### DIFF
--- a/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/MyPageFragment.kt
@@ -433,20 +433,25 @@ class MyPageFragment : Fragment() {
         sharedViewModel.synchronizationDataWithBtn()
     }
 
-
     // Edit user name
     private fun showEditNameDialog() = with(binding) {
         val currentName = mypageEtName.text.toString()
-        MyPageEditNameDialog(requireContext(), currentName) { newName ->
-            mypageEtName.text = newName
-            updateProfileName(newName)
-
-            key = firebase.auth.currentUser?.uid ?: ""
-            name = newName
-            id = firebase.auth.currentUser?.email ?: ""
-            img = (firebase.auth.currentUser?.photoUrl ?: "").toString()
-            viewModel.storeUser(key = key, name = name, id = id, img = img)
+        val dialog = MyPageEditNameDialog(currentName) { newName ->
+            updateName(newName)
         }
+        dialog.show(parentFragmentManager, "MyPageEditNameDialog")
+    }
+
+    private fun updateName(newName: String) = with(binding) {
+        val currentUser = firebase.auth.currentUser
+        mypageEtName.text = newName
+        updateProfileName(newName)
+
+        key = currentUser?.uid ?: ""
+        name = newName
+        id = currentUser?.email ?: ""
+        img = (currentUser?.photoUrl ?: "").toString()
+        viewModel.storeUser(key = key, name = name, id = id, img = img)
     }
 
     // Change the password

--- a/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/mypagedialog/MyPageChangePasswordDialog.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/mypagedialog/MyPageChangePasswordDialog.kt
@@ -12,7 +12,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
-import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
@@ -20,6 +19,7 @@ import com.google.firebase.auth.EmailAuthProvider
 import com.google.firebase.auth.FirebaseAuth
 import com.nbcam_final_account_book.R
 import com.nbcam_final_account_book.databinding.MyPageChangePasswordDialogBinding
+import com.nbcam_final_account_book.util.ContextUtil.showToast
 
 class MyPageChangePasswordDialog : DialogFragment() {
 
@@ -115,17 +115,17 @@ class MyPageChangePasswordDialog : DialogFragment() {
                         currentUser.updatePassword(newPassword)
                             .addOnCompleteListener { passwordUpdateTask ->
                                 if (passwordUpdateTask.isSuccessful) {
-                                    mContext.showToast("비밀번호가 변경되었습니다.")
+                                    showToast(mContext,"비밀번호가 변경되었습니다.")
                                     dismiss()
                                 } else {
-                                    mContext.showToast("비밀번호 변경에 실패했습니다.")
+                                    showToast(mContext,"비밀번호 변경에 실패했습니다.")
                                 }
                             }
                     } else {
-                        mContext.showToast("새로운 비밀번호와 확인 비밀번호가 일치하지 않습니다.")
+                        showToast(mContext, "새로운 비밀번호와 확인 비밀번호가 일치하지 않습니다.")
                     }
                 } else {
-                    mContext.showToast("현재 비밀번호가 올바르지 않습니다.")
+                    showToast(mContext, "현재 비밀번호가 올바르지 않습니다.")
                 }
             }
     }
@@ -160,9 +160,5 @@ class MyPageChangePasswordDialog : DialogFragment() {
     private fun isPasswordValid(password: String): Boolean {
         val passwordRegex = Regex("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#\$%^&*]).{8,20}\$")
         return passwordRegex.matches(password)
-    }
-
-    private fun Context.showToast(msg: String) {
-        Toast.makeText(this, msg, Toast.LENGTH_LONG).show()
     }
 }

--- a/app/src/main/java/com/nbcam_final_account_book/util/ContextUtil.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/util/ContextUtil.kt
@@ -1,0 +1,10 @@
+package com.nbcam_final_account_book.util
+
+import android.content.Context
+import android.widget.Toast
+
+object ContextUtil {
+    fun showToast(context: Context, msg: String) {
+        Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/res/layout/my_page_edit_name_dialog.xml
+++ b/app/src/main/res/layout/my_page_edit_name_dialog.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/padding">
+    android:background="@drawable/shape_round"
+    android:padding="@dimen/padding"
+    tools:context=".persentation.mypage.mypagedialog.MyPageEditNameDialog">
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/edit_name_input_layout"
@@ -22,4 +25,41 @@
             android:layout_height="wrap_content"
             android:hint="새 이름" />
     </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:id="@+id/tv_dialog_cancel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="10dp"
+        android:text="취소"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/divider"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/edit_name_input_layout" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="1dp"
+        android:layout_height="0dp"
+        android:background="@color/text_primary"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="@+id/tv_dialog_cancel"
+        app:layout_constraintEnd_toStartOf="@+id/tv_dialog_save"
+        app:layout_constraintStart_toEndOf="@+id/tv_dialog_cancel"
+        app:layout_constraintTop_toTopOf="@+id/tv_dialog_cancel" />
+
+    <TextView
+        android:id="@+id/tv_dialog_save"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="저장"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+        android:textColor="@color/btn_text_color"
+        app:layout_constraintBottom_toBottomOf="@+id/divider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/divider"
+        app:layout_constraintTop_toTopOf="@+id/divider" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 구현 사항
1. 이름 수정 시 Firestore에 업데이트
- MyPageViewModel에 `updateUserNameInFirestore` 메서드 작성
2. MyPageEditNameDialog 코드 리팩토링
    - DialogFragment 상속
    - ViewBinding 사용
3.  my_page_edit_name_dialog UI 수정
    - 취소/저장 버튼 추가
    - background 설정
## 주요 변동 파일
- MyPageFragment.kt
- MyPageViewModel.kt
- MyPageEditNameDialog .kt
- my_page_edit_name_dialog .xml
---
close #253 