### PR TITLE
계정삭제 다이얼로그 수정

### DIFF
--- a/app/src/main/java/com/nbcam_final_account_book/data/repository/firebase/FireBaseRepository.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/data/repository/firebase/FireBaseRepository.kt
@@ -17,12 +17,12 @@ interface FireBaseRepository {
 
     suspend fun updateUserInFireStore(user: UserDataEntity)
     suspend fun deleteUserInFireStore(email: String)
-    suspend fun getUserInFireStore(uid: String) : UserDataEntity?
+    suspend fun getUserInFireStore(uid: String): UserDataEntity?
 
     // Shared
 
     suspend fun getAllUsers(): List<UserDataEntity> // 모든유저 데이터를 가져옴
-    suspend fun searchUserDataInFireStore(keyword:String) : List<UserDataEntity> //email or name으로 검색
+    suspend fun searchUserDataInFireStore(keyword: String): List<UserDataEntity> //email or name으로 검색
 
     suspend fun sharedTemplate(path: String, template: TemplateEntity)
 
@@ -43,5 +43,5 @@ interface FireBaseRepository {
     suspend fun getBackupData(user: String): List<DataEntity>
 
     suspend fun deleteData(user: String, key: String)
-
+    suspend fun deleteUserInRealtimeDB(uid: String)
 }

--- a/app/src/main/java/com/nbcam_final_account_book/data/repository/firebase/FireBaseRepositoryImpl.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/data/repository/firebase/FireBaseRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package com.nbcam_final_account_book.data.repository.firebase
 
-import android.net.wifi.WifiConfiguration.AuthAlgorithm.SHARED
 import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.ktx.database
@@ -14,82 +13,80 @@ import com.nbcam_final_account_book.unit.Unit.TEMPLATE_LIST
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
-import java.lang.Exception
-import com.nbcam_final_account_book.unit.Unit
 
 class FireBaseRepositoryImpl(
 
 ) : FireBaseRepository {
 
-	//user 관리
-	override fun getUser(): String {
-		val user = FirebaseAuth.getInstance().currentUser
-		return user?.uid ?: ""
-	}
+    //user 관리
+    override fun getUser(): String {
+        val user = FirebaseAuth.getInstance().currentUser
+        return user?.uid ?: ""
+    }
 
-	override fun logout() {
-		val auth = FirebaseAuth.getInstance()
-		auth.signOut()
-	}
+    override fun logout() {
+        val auth = FirebaseAuth.getInstance()
+        auth.signOut()
+    }
 
-	override suspend fun updateUserInFireStore(user: UserDataEntity) {
-		val db = Firebase.firestore
-		val id = user.id
+    override suspend fun updateUserInFireStore(user: UserDataEntity) {
+        val db = Firebase.firestore
+        val id = user.id
 
-		val userData = hashMapOf(
-			"uid" to user.key,
-			"name" to user.name,
-			"email" to user.id,
-			"photoUrl" to user.img,
-		)
-
-
-		db.collection("Users").document(user.id).set(userData)
-			.addOnSuccessListener {
-				Log.d(
-					"firestore successfully",
-					"DocumentSnapshot successfully written!"
-				)
-			}
-			.addOnFailureListener { e -> Log.w("firestore error", "Error writing document", e) }
+        val userData = hashMapOf(
+            "uid" to user.key,
+            "name" to user.name,
+            "email" to user.id,
+            "photoUrl" to user.img,
+        )
 
 
-	}
+        db.collection("Users").document(user.id).set(userData)
+            .addOnSuccessListener {
+                Log.d(
+                    "firestore successfully",
+                    "DocumentSnapshot successfully written!"
+                )
+            }
+            .addOnFailureListener { e -> Log.w("firestore error", "Error writing document", e) }
 
-	override suspend fun deleteUserInFireStore(email: String) {
-		val db = Firebase.firestore
-		db.collection("Users").document(email).delete()
-	}
 
-	override suspend fun getUserInFireStore(uid: String): UserDataEntity? {
-		val db = Firebase.firestore
+    }
 
-		try {
-			val responseData = db.collection("Users")
-				.whereEqualTo("uid", uid)
-				.get()
-				.await()
+    override suspend fun deleteUserInFireStore(email: String) {
+        val db = Firebase.firestore
+        db.collection("Users").document(email).delete()
+    }
 
-			var resultUserData: UserDataEntity? = null
+    override suspend fun getUserInFireStore(uid: String): UserDataEntity? {
+        val db = Firebase.firestore
 
-			for (document in responseData) {
-				val uid = document.getString("uid") ?: ""
-				val name = document.getString("name") ?: ""
-				val email = document.getString("email") ?: ""
-				val photoUrl = document.getString("photoUrl") ?: ""
+        try {
+            val responseData = db.collection("Users")
+                .whereEqualTo("uid", uid)
+                .get()
+                .await()
 
-				val userData = UserDataEntity(key = uid, name = name, id = email, img = photoUrl)
-				resultUserData = userData
-			}
+            var resultUserData: UserDataEntity? = null
 
-			return resultUserData
+            for (document in responseData) {
+                val uid = document.getString("uid") ?: ""
+                val name = document.getString("name") ?: ""
+                val email = document.getString("email") ?: ""
+                val photoUrl = document.getString("photoUrl") ?: ""
 
-		} catch (e: Exception) {
-			Log.e("FirebaseRepo", "UserData 가져오기 중 오류 발생")
-			return null
-		}
+                val userData = UserDataEntity(key = uid, name = name, id = email, img = photoUrl)
+                resultUserData = userData
+            }
 
-	}
+            return resultUserData
+
+        } catch (e: Exception) {
+            Log.e("FirebaseRepo", "UserData 가져오기 중 오류 발생")
+            return null
+        }
+
+    }
 
     override suspend fun getAllUsers(): List<UserDataEntity> = withContext(Dispatchers.IO) {
         val db = Firebase.firestore
@@ -112,192 +109,199 @@ class FireBaseRepositoryImpl(
 
     override suspend fun searchUserDataInFireStore(keyword: String): List<UserDataEntity> =
         withContext(Dispatchers.IO) {
-        val db = Firebase.firestore
+            val db = Firebase.firestore
 
-		try {
-			val nameQuery = db.collection("Users")
-				.whereEqualTo("name", keyword)
-				.get()
-				.await()
+            try {
+                val nameQuery = db.collection("Users")
+                    .whereEqualTo("name", keyword)
+                    .get()
+                    .await()
 
-			val emailQuery = db.collection("Users")
-				.whereEqualTo("email", keyword)
-				.get()
-				.await()
+                val emailQuery = db.collection("Users")
+                    .whereEqualTo("email", keyword)
+                    .get()
+                    .await()
 
-			val resultUserDataList: MutableList<UserDataEntity> = mutableListOf()
+                val resultUserDataList: MutableList<UserDataEntity> = mutableListOf()
 
-			for (document in nameQuery) {
-				val uid = document.getString("uid") ?: ""
-				val name = document.getString("name") ?: ""
-				val email = document.getString("email") ?: ""
-				val photoUrl = document.getString("photoUrl") ?: ""
+                for (document in nameQuery) {
+                    val uid = document.getString("uid") ?: ""
+                    val name = document.getString("name") ?: ""
+                    val email = document.getString("email") ?: ""
+                    val photoUrl = document.getString("photoUrl") ?: ""
 
-				val userData = UserDataEntity(key = uid, name = name, id = email, img = photoUrl)
+                    val userData =
+                        UserDataEntity(key = uid, name = name, id = email, img = photoUrl)
 
-				resultUserDataList.add(userData)
-			}
+                    resultUserDataList.add(userData)
+                }
 
-			for (document in emailQuery) {
-				val uid = document.getString("uid") ?: ""
-				val name = document.getString("name") ?: ""
-				val email = document.getString("email") ?: ""
-				val photoUrl = document.getString("photoUrl") ?: ""
+                for (document in emailQuery) {
+                    val uid = document.getString("uid") ?: ""
+                    val name = document.getString("name") ?: ""
+                    val email = document.getString("email") ?: ""
+                    val photoUrl = document.getString("photoUrl") ?: ""
 
-				val userData = UserDataEntity(key = uid, name = name, id = email, img = photoUrl)
+                    val userData =
+                        UserDataEntity(key = uid, name = name, id = email, img = photoUrl)
 
 
-				if (!resultUserDataList.contains(userData)) {
-					resultUserDataList.add(userData)
-				}
-			}
+                    if (!resultUserDataList.contains(userData)) {
+                        resultUserDataList.add(userData)
+                    }
+                }
 
-            resultUserDataList
+                resultUserDataList
 
-        } catch (e: Exception) {
-            Log.e("FirebaseRepo", "UserData 가져오기 중 오류 발생: ${e.message}")
-            emptyList()
+            } catch (e: Exception) {
+                Log.e("FirebaseRepo", "UserData 가져오기 중 오류 발생: ${e.message}")
+                emptyList()
+            }
         }
-    }
 
-	override suspend fun sharedTemplate(path: String, template: TemplateEntity) {
-		val database = Firebase.database
-		val myRef = database.getReference(path)
-		myRef.child(template.id).setValue(template)
-	}
+    override suspend fun sharedTemplate(path: String, template: TemplateEntity) {
+        val database = Firebase.database
+        val myRef = database.getReference(path)
+        myRef.child(template.id).setValue(template)
+    }
 
 
 //Template
 
-	override suspend fun getAllTemplate(user: String): List<TemplateEntity> {
-		val database = Firebase.database
-		val path = "$user/$TEMPLATE_LIST/TEMPLATE"
+    override suspend fun getAllTemplate(user: String): List<TemplateEntity> {
+        val database = Firebase.database
+        val path = "$user/$TEMPLATE_LIST/TEMPLATE"
 
-		try {
-			val snapshot = database.getReference(path).get().await()
+        try {
+            val snapshot = database.getReference(path).get().await()
 
-			return if (snapshot.exists()) {
-				val responseList = mutableListOf<TemplateEntity>()
-				for (userSnapshot in snapshot.children) {
-					val getData = userSnapshot.getValue(TemplateEntity::class.java)
+            return if (snapshot.exists()) {
+                val responseList = mutableListOf<TemplateEntity>()
+                for (userSnapshot in snapshot.children) {
+                    val getData = userSnapshot.getValue(TemplateEntity::class.java)
 
-					getData?.let {
+                    getData?.let {
 
-						responseList.add(getData)
-					}
-				}
-				responseList
-			} else {
-				emptyList()
-			}
-		} catch (e: Exception) {
+                        responseList.add(getData)
+                    }
+                }
+                responseList
+            } else {
+                emptyList()
+            }
+        } catch (e: Exception) {
 
-			Log.e("FirebaseRepo", "Tag 데이터 가져오기 중 오류 발생")
-			return emptyList()
-		}
-	}
+            Log.e("FirebaseRepo", "Tag 데이터 가져오기 중 오류 발생")
+            return emptyList()
+        }
+    }
 
-	override suspend fun setTemplate(user: String, item: TemplateEntity): List<TemplateEntity> {
-		val database = Firebase.database
-		val path = "$user/$TEMPLATE_LIST/TEMPLATE"
-		val myRef = database.getReference(path)
+    override suspend fun setTemplate(user: String, item: TemplateEntity): List<TemplateEntity> {
+        val database = Firebase.database
+        val path = "$user/$TEMPLATE_LIST/TEMPLATE"
+        val myRef = database.getReference(path)
 
-		myRef.child(item.id).setValue(item)
+        myRef.child(item.id).setValue(item)
 
-		try {
-			val snapshot = database.getReference(path).get().await()
+        try {
+            val snapshot = database.getReference(path).get().await()
 
-			if (snapshot.exists()) {
-				val responseList = mutableListOf<TemplateEntity>()
-				for (userSnapshot in snapshot.children) {
-					val getData = userSnapshot.getValue(TemplateEntity::class.java)
+            if (snapshot.exists()) {
+                val responseList = mutableListOf<TemplateEntity>()
+                for (userSnapshot in snapshot.children) {
+                    val getData = userSnapshot.getValue(TemplateEntity::class.java)
 
-					getData?.let {
+                    getData?.let {
 
-						responseList.add(getData)
-					}
-				}
-				return responseList
-			} else {
-				return emptyList()
-			}
-		} catch (e: Exception) {
+                        responseList.add(getData)
+                    }
+                }
+                return responseList
+            } else {
+                return emptyList()
+            }
+        } catch (e: Exception) {
 
-			Log.e("FirebaseRepo", "Tag 데이터 가져오기 중 오류 발생")
-			return emptyList()
-		}
-	}
+            Log.e("FirebaseRepo", "Tag 데이터 가져오기 중 오류 발생")
+            return emptyList()
+        }
+    }
 
-	override suspend fun setTemplateList(user: String, items: List<TemplateEntity>) {
-		val database = Firebase.database
-		val path = "$user/$TEMPLATE_LIST/TEMPLATE"
-		val myRef = database.getReference(path)
-		for (item in items) {
-			myRef.child(item.id).setValue(item)
-		}
+    override suspend fun setTemplateList(user: String, items: List<TemplateEntity>) {
+        val database = Firebase.database
+        val path = "$user/$TEMPLATE_LIST/TEMPLATE"
+        val myRef = database.getReference(path)
+        for (item in items) {
+            myRef.child(item.id).setValue(item)
+        }
 
-	}
+    }
 
-	override suspend fun deleteTemplate(user: String, key: String) {
-		val database = Firebase.database
-		val myRef = database.getReference("$user/$TEMPLATE_LIST/TEMPLATE")
+    override suspend fun deleteTemplate(user: String, key: String) {
+        val database = Firebase.database
+        val myRef = database.getReference("$user/$TEMPLATE_LIST/TEMPLATE")
 
-		myRef.child(key).removeValue()
-	}
+        myRef.child(key).removeValue()
+    }
 
-	override suspend fun updateData(user: String, item: DataEntity) {
-		val database = Firebase.database
-		val path = "$user/$TEMPLATE_DATA"
-		val myRef = database.getReference(path)
+    override suspend fun updateData(user: String, item: DataEntity) {
+        val database = Firebase.database
+        val path = "$user/$TEMPLATE_DATA"
+        val myRef = database.getReference(path)
 
-		myRef.child(item.id).setValue(item)
-	}
+        myRef.child(item.id).setValue(item)
+    }
 
-	override suspend fun updateDataList(user: String, items: List<DataEntity>) {
-		val database = Firebase.database
-		val path = "$user/$TEMPLATE_DATA"
-		val myRef = database.getReference(path)
+    override suspend fun updateDataList(user: String, items: List<DataEntity>) {
+        val database = Firebase.database
+        val path = "$user/$TEMPLATE_DATA"
+        val myRef = database.getReference(path)
 
-		for (item in items) {
-			myRef.child(item.id).setValue(item)
-		}
+        for (item in items) {
+            myRef.child(item.id).setValue(item)
+        }
 
-	}
+    }
 
-	override suspend fun getBackupData(user: String): List<DataEntity> {
-		val database = Firebase.database
-		val path = "$user/$TEMPLATE_DATA"
-		try {
-			val snapshot = database.getReference(path).get().await()
+    override suspend fun getBackupData(user: String): List<DataEntity> {
+        val database = Firebase.database
+        val path = "$user/$TEMPLATE_DATA"
+        try {
+            val snapshot = database.getReference(path).get().await()
 
-			return if (snapshot.exists()) {
-				val responseList = mutableListOf<DataEntity>()
-				for (userSnapshot in snapshot.children) {
-					val getData = userSnapshot.getValue(DataEntity::class.java)
+            return if (snapshot.exists()) {
+                val responseList = mutableListOf<DataEntity>()
+                for (userSnapshot in snapshot.children) {
+                    val getData = userSnapshot.getValue(DataEntity::class.java)
 
-					getData?.let {
+                    getData?.let {
 
-						responseList.add(getData)
-					}
-				}
-				responseList
-			} else {
-				emptyList()
-			}
-		} catch (e: Exception) {
+                        responseList.add(getData)
+                    }
+                }
+                responseList
+            } else {
+                emptyList()
+            }
+        } catch (e: Exception) {
 
-			Log.e("FirebaseRepo", "BackupData 데이터 가져오기 중 오류 발생")
-			return emptyList()
-		}
-	}
+            Log.e("FirebaseRepo", "BackupData 데이터 가져오기 중 오류 발생")
+            return emptyList()
+        }
+    }
 
-	override suspend fun deleteData(user: String, key: String) {
-		val database = Firebase.database
-		val path = "$user/$TEMPLATE_DATA"
-		val myRef = database.getReference(path)
+    override suspend fun deleteData(user: String, key: String) {
+        val database = Firebase.database
+        val path = "$user/$TEMPLATE_DATA"
+        val myRef = database.getReference(path)
 
-		myRef.child(key).removeValue()
-	}
+        myRef.child(key).removeValue()
+    }
 
+    override suspend fun deleteUserInRealtimeDB(uid: String) {
+        val database = Firebase.database
+        val userRef = database.getReference(uid)
 
+        userRef.removeValue()
+    }
 }

--- a/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/MyPageViewModel.kt
@@ -258,6 +258,12 @@ class MyPageViewModel(
         }
     }
 
+    fun deleteUserInRealtimeDB(uid: String) {
+        viewModelScope.launch {
+            fireRepo.deleteUserInRealtimeDB(uid)
+        }
+    }
+
     fun deleteAllData(user: String, key: String, email: String) {
         deleteData(user, key)
         deleteUserInFireStore(email)

--- a/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/mypagedialog/MyPageWithdrawDialog.kt
+++ b/app/src/main/java/com/nbcam_final_account_book/persentation/mypage/mypagedialog/MyPageWithdrawDialog.kt
@@ -1,28 +1,83 @@
 package com.nbcam_final_account_book.persentation.mypage.mypagedialog
 
+import android.app.Dialog
 import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
+import android.view.Window
 import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
 import com.nbcam_final_account_book.R
+import com.nbcam_final_account_book.databinding.MyPageWithdrawDialogBinding
 
-class MyPageWithdrawDialog(context: Context, onWithdrawConfirmed: () -> Unit) {
-    private val dialog: AlertDialog
+class MyPageWithdrawDialog(private val onWithdrawConfirmed: () -> Unit) : DialogFragment() {
 
-    init {
-        val builder = AlertDialog.Builder(context, R.style.EditNameAlertDialogStyle)
-        val customView = View.inflate(context, R.layout.my_page_withdraw_dialog, null)
+    private var _binding: MyPageWithdrawDialogBinding? = null
+    private val binding get() = _binding!!
+    private lateinit var mContext: Context
+    private lateinit var alertDialog: AlertDialog
 
-        builder.apply {
-            setView(customView)
-            setPositiveButton("확인") { _, _ ->
-                onWithdrawConfirmed()
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        mContext = context
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = MyPageWithdrawDialogBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        _binding = MyPageWithdrawDialogBinding.inflate(layoutInflater, null, false)
+        val dialog = Dialog(requireContext())
+        dialog.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        dialog.requestWindowFeature(Window.FEATURE_NO_TITLE)
+        dialog.setContentView(binding.root)
+        return dialog
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        val width = (resources.displayMetrics.widthPixels * 0.85).toInt()
+        val height = ViewGroup.LayoutParams.WRAP_CONTENT
+        dialog?.window?.setLayout(width, height)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initView()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun initView() = with(binding){
+        alertDialog = AlertDialog.Builder(mContext, R.style.EditNameAlertDialogStyle)
+            .setView(root)
+            .setNegativeButton("취소", null)
+            .setPositiveButton("저장", null)
+            .create().apply {
+                setCancelable(false)
             }
-            setNegativeButton("취소") { dialog, _ ->
-                dialog.dismiss()
-            }
+
+        tvDialogCancel.setOnClickListener {
+            dismiss()
         }
 
-        dialog = builder.create()
-        dialog.show()
+        tvDialogOkay.setOnClickListener {
+            onWithdrawConfirmed()
+            dismiss()
+        }
     }
 }

--- a/app/src/main/res/layout/my_page_withdraw_dialog.xml
+++ b/app/src/main/res/layout/my_page_withdraw_dialog.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/padding">
+    android:background="@drawable/shape_round"
+    android:padding="@dimen/padding"
+    tools:context=".persentation.mypage.mypagedialog.MyPageWithdrawDialog">
 
     <TextView
         android:id="@+id/withdraw_question"
@@ -19,11 +22,49 @@
         android:id="@+id/withdraw_desc"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_top"
         android:text="지금까지의 데이터가 모두 사라집니다."
         android:textColor="@color/text_hint"
         android:textSize="16sp"
-        android:layout_marginTop="@dimen/margin_top"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/withdraw_question" />
+
+    <TextView
+        android:id="@+id/tv_dialog_cancel"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="5dp"
+        android:layout_marginTop="20dp"
+        android:text="취소"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/divider"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/withdraw_desc" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="1dp"
+        android:layout_height="0dp"
+        android:background="@color/text_primary"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="@+id/tv_dialog_cancel"
+        app:layout_constraintEnd_toStartOf="@+id/tv_dialog_okay"
+        app:layout_constraintStart_toEndOf="@+id/tv_dialog_cancel"
+        app:layout_constraintTop_toTopOf="@+id/tv_dialog_cancel" />
+
+    <TextView
+        android:id="@+id/tv_dialog_okay"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="확인"
+        android:textAlignment="center"
+        android:textAppearance="@style/TextAppearance.AppCompat.Body2"
+        android:textColor="@color/btn_text_color"
+        app:layout_constraintBottom_toBottomOf="@+id/divider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/divider"
+        app:layout_constraintTop_toTopOf="@+id/divider" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## 구현 사항
1. 계정삭제 시 Realtime DB에서도 삭제
    - FireBaseRepository, FireBaseRepositoryImpl, MyPageViewModel에 deleteUserInRealtimeDB 추가
2. MyPageWithdrawDialog 코드 리팩토링
    - DialogFragment 상속
    - ViewBinding 사용
3. my_page_withdraw_dialog UI 수정
    - 취소/저장 버튼 추가
    - background 설정
## 주요 변동 파일
- FireBaseRepository.kt
- FireBaseRepositoryImpl.kt
- MyPageFragment.kt
- MyPageViewModel.kt
- MyPageWithdrawDialog.kt
- my_page_withdraw_dialog.xml
---
close #255 